### PR TITLE
DRIVERS-3217 Investigate error rate tracking for server selection

### DIFF
--- a/pymongo/asynchronous/topology.py
+++ b/pymongo/asynchronous/topology.py
@@ -391,10 +391,17 @@ class Topology:
         if len(servers) == 1:
             return servers[0]
         server1, server2 = random.sample(servers, 2)
-        if server1.pool.operation_count <= server2.pool.operation_count:
+        error_rate1 = await server1.pool.get_error_rate()
+        error_rate2 = await server2.pool.get_error_rate()
+        if error_rate1 < error_rate2 and (random.random() < (error_rate2 - error_rate1)):  # noqa: S311
             return server1
-        else:
+        elif error_rate1 > error_rate2 and (random.random() < (error_rate1 - error_rate2)):  # noqa: S311
             return server2
+        else:
+            if server1.pool.operation_count <= server2.pool.operation_count:
+                return server1
+            else:
+                return server2
 
     async def select_server(
         self,

--- a/pymongo/synchronous/pool.py
+++ b/pymongo/synchronous/pool.py
@@ -811,6 +811,14 @@ class Pool:
         self.__pinned_sockets: set[Connection] = set()
         self.ncursors = 0
         self.ntxns = 0
+        self.error_times: collections.deque[tuple[float, int]] = collections.deque()
+
+    def get_error_rate(self) -> float:
+        with self.lock:
+            # Require at least 10 samples to compute an error rate.
+            if len(self.error_times) < 10:
+                return 0.0
+            return sum(t[1] for t in self.error_times) / (len(self.error_times) or 1)
 
     def ready(self) -> None:
         # Take the lock to avoid the race condition described in PYTHON-2699.
@@ -1178,7 +1186,16 @@ class Pool:
                 serverPort=self.address[1],
             )
 
-        conn = self._get_conn(checkout_started_time, handler=handler)
+        try:
+            conn = self._get_conn(checkout_started_time, handler=handler)
+        except Exception:
+            self.error_times.append((time.monotonic(), 1))
+            raise
+
+        # clear old info from error rate >10 seconds old
+        watermark = time.monotonic() - 10
+        while self.error_times and self.error_times[0][0] < watermark:
+            self.error_times.popleft()
 
         duration = time.monotonic() - checkout_started_time
         if self.enabled_for_cmap:
@@ -1198,8 +1215,10 @@ class Pool:
             with self.lock:
                 self.active_contexts.add(conn.cancel_context)
             yield conn
+            self.error_times.append((time.monotonic(), 0))
         # Catch KeyboardInterrupt, CancelledError, etc. and cleanup.
         except BaseException:
+            self.error_times.append((time.monotonic(), 1))
             # Exception in caller. Ensure the connection gets returned.
             # Note that when pinned is True, the session owns the
             # connection and it is responsible for checking the connection

--- a/pymongo/synchronous/topology.py
+++ b/pymongo/synchronous/topology.py
@@ -391,10 +391,17 @@ class Topology:
         if len(servers) == 1:
             return servers[0]
         server1, server2 = random.sample(servers, 2)
-        if server1.pool.operation_count <= server2.pool.operation_count:
+        error_rate1 = server1.pool.get_error_rate()
+        error_rate2 = server2.pool.get_error_rate()
+        if error_rate1 < error_rate2 and (random.random() < (error_rate2 - error_rate1)):  # noqa: S311
             return server1
-        else:
+        elif error_rate1 > error_rate2 and (random.random() < (error_rate1 - error_rate2)):  # noqa: S311
             return server2
+        else:
+            if server1.pool.operation_count <= server2.pool.operation_count:
+                return server1
+            else:
+                return server2
 
     def select_server(
         self,


### PR DESCRIPTION
Changes:
- DRIVERS-3217 Investigate error rate tracking for server selection
- Add test for overload using activationProbability (sync only so would need to be converted to async.)

The driver tracks the pass/fail rate of every operation for each server. In server selection rather than purely using "operation count" we bias towards the server with the lower error rate. So if server A has an error rate of 75% and server B is 25%, then 75-25 = 50% of the time we select Server B and the other 50% we use the existing "operation count" logic. This appears to work well, before this change the test sees a ~60% error rate:
```
Overloaded server: ('localhost', 27017)
{('localhost', 27017): 0.77975, ('localhost', 27018): 0.22025, 'overload_errors': 2344, 'operations': 4000, 'error_rate': 0.586}
```
After this change there's an ~20% error rate:
```
Overloaded server: ('localhost', 27017)
{('localhost', 27017): 0.239, ('localhost', 27018): 0.761, 'overload_errors': 731, 'operations': 4000, 'error_rate': 0.18275}
```

Concerns:
- Runtime perf cost of tracking the error rate. It should not slow down the happy path. We may want to cap the number of samples (not just their age) to limit memory usage. We may also need to cache the error rate rather than dynamically calculating it for every server selection call. 
- Some exceptions are normal "success" results which we should not label as failures counted towards the error rate. One example is duplicate key errors. It will be safer to only track errors with the "SystemOverloadedError" label.